### PR TITLE
sg_raw: Fix version print command

### DIFF
--- a/src/sg_raw.c
+++ b/src/sg_raw.c
@@ -300,19 +300,19 @@ parse_cmd_line(struct opts_t * op, int argc, char *argv[])
         }
     }
 
-    if (optind >= argc) {
-        pr2serr("No device specified\n");
-        return SG_LIB_SYNTAX_ERROR;
-    }
-    op->device_name = argv[optind];
-    ++optind;
-
     if (op->version_given
 #ifdef DEBUG
         && ! op->verbose_given
 #endif
        )
         return 0;
+
+    if (optind >= argc) {
+        pr2serr("No device specified\n");
+        return SG_LIB_SYNTAX_ERROR;
+    }
+    op->device_name = argv[optind];
+    ++optind;
 
     while (optind < argc) {
         char *opt = argv[optind++];


### PR DESCRIPTION
Avoid printing "No device specified" error and exit gracefully with a zero.

----

This is a correction of a previous change (commit 6a2fe0f14972e955e466a0d36f3a8b1d15dc3fcc, svn r872) that was misplaced.

The original change proposal was here: https://github.com/hreinecke/sg3_utils/pull/40