### PR TITLE
sg_get_elem_status: Fix a max_len boundary check

### DIFF
--- a/src/sg_get_elem_status.c
+++ b/src/sg_get_elem_status.c
@@ -295,7 +295,7 @@ main(int argc, char * argv[])
             }
             if (0 == maxlen)
                 maxlen = DEF_GPES_BUFF_LEN;
-            else if (n < MIN_MAXLEN) {
+            else if (maxlen < MIN_MAXLEN) {
                 pr2serr("Warning: --maxlen=LEN less than %d ignored\n",
                         MIN_MAXLEN);
                 maxlen = DEF_GPES_BUFF_LEN;


### PR DESCRIPTION
A small issue reported by clang. Please double-check that my logic in the fix is correct.

```
sg3_utils-1.47r908/src/sg_get_elem_status.c:295:24: warning[core.UndefinedBinaryOperatorResult]: The left operand of '<' is a garbage value
   293|               if (0 == maxlen)
   294|                   maxlen = DEF_GPES_BUFF_LEN;
   295|->             else if (n < MIN_MAXLEN) {
   296|                   pr2serr("Warning: --maxlen=LEN less than %d ignored\n",
   297|                           MIN_MAXLEN);
```