### PR TITLE
Fix build with gcc 4.8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_PROG_LIBTOOL
 
 # check for headers
 AC_HEADER_STDC
-AC_CHECK_HEADERS([byteswap.h], [], [], [])
+AC_CHECK_HEADERS([byteswap.h stdatomic.h], [], [], [])
 
 # check for functions
 AC_CHECK_FUNCS(getopt_long,

--- a/src/sgp_dd.c
+++ b/src/sgp_dd.c
@@ -60,7 +60,7 @@
 #include <linux/fs.h>           /* for BLKSSZGET and friends */
 
 #ifdef __STDC_VERSION__
-#if __STDC_VERSION__ >= 201112L
+#if __STDC_VERSION__ >= 201112L && defined(HAVE_STDATOMIC_H)
 #ifndef __STDC_NO_ATOMICS__
 
 #define HAVE_C11_ATOMICS


### PR DESCRIPTION
Check if `stdatomic.h` is available before using it to fix the following build failure raised since version 1.46 and https://github.com/hreinecke/sg3_utils/commit/e9445f4efc012d37809342ba21f16360a0208f06:

```
sgp_dd.c:67:23: fatal error: stdatomic.h: No such file or directory
 #include <stdatomic.h>
                       ^
```

Fixes:
 - http://autobuild.buildroot.org/results/2f531a187dd8e4c709bc0d81f8d4cb36ef5f5437

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>