### PR TITLE
55-scsi-sg3_id.rules: remove special case for SPC devices

### DIFF
--- a/scripts/55-scsi-sg3_id.rules
+++ b/scripts/55-scsi-sg3_id.rules
@@ -42,12 +42,6 @@ KERNEL!="sd*[!0-9]|sr*", GOTO="sg3_utils_id_end"
 LABEL="scsi_inquiry"
 ENV{ID_SCSI_INQUIRY}=="0", GOTO="sg_inquiry"
 
-# As of 2018/4.15, the kernel doesn't provide VPD pages for "SPC" devices
-# (SCSI version 0x03, ANSI INCITS 301-1997) in sysfs.
-# It's usually safe to try though (no counter-example is known),
-# and for scsi_id compatibility, we have to try.
-SUBSYSTEMS=="scsi", ATTRS{scsi_level}=="4", GOTO="sg_inquiry"
-
 # "inquiry" is an attribute of the scsi_device in sysfs,
 # we obtain it by using $id after an ATTRS match.
 SUBSYSTEMS=="scsi", ATTRS{inquiry}=="*", KERNELS=="[0-9]*:*[0-9]", \


### PR DESCRIPTION
This rule is superfluous. If the "inquiry" attribute doesn't exist,
we'll fallback to sg_inq anyway. There's only one failure mode: if
"inquiry" sysfs attribute exists and the vpd_pg80/83 sysfs attributes
don't, while fetching the VPD pages from the device would still succeed.

For this case, the kernel offers the devinfo flag `BLIST_TRY_VPD_PAGES`
(0x10000000) to try retrieving VPD pages even if the SCSI level suggests they
aren't supported (most prominently, this applies to OPEN-V devices).
Setting the devinfo flag is more reliable and more specific than anything
we might try in this udev rule.

To set the flag at runtime for some device (in case the kernel doesn't
have it built in yet), use the kernel parameter

     scsi_mod.scsi_dev_flags=$VENDOR:$PRODUCT:0x10000000