### PR TITLE
configure.ac: fix uclibc-ng build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,7 +107,7 @@ case "${host}" in
 		AC_DEFINE_UNQUOTED(HAVE_NVME, 1, [Found NVMe])
 		check_for_getrandom
                 CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO";;
-        *-*-linux-gnu* | *-*-linux*)
+        *-*-linux-gnu* | *-*-linux* | *-*-uclinux-gnu* | *-*-uclinux*)
                 AC_DEFINE_UNQUOTED(SG_LIB_LINUX, 1, [sg3_utils on linux])
 		check_for_linux_sg_v4_hdr
 		check_for_getrandom


### PR DESCRIPTION
Fix the following build failure with uclibc-ng raised because `SG_IO` is not defined:

```
/home/buildroot/autobuild/instance-3/output-1/host/opt/ext-toolchain/arm-buildroot-uclinux-uclibcgnueabi/bin/ld.real: sg_dd.o: in function `sg_read_low.constprop.0':
sg_dd.c:(.text+0xc6c): undefined reference to `sg_chk_n_print3'
```

Fixes:
 - http://autobuild.buildroot.org/results/38a0dfc70a21ce574368b7a485deb231f778b3e7

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>