### PR TITLE
Fix a build error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+# See also https://docs.github.com/en/actions/learn-github-actions/expressions
+# See also https://github.com/marketplace/actions/setup-android-ndk
+
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+        - android
+        - linux-gcc
+        - linux-clang
+        - linux-x86-gcc
+        - linux-powerpc64-gcc
+        - linux-mingw64-gcc
+        - macos
+        include:
+        - build: android
+          cc: clang
+          host: aarch64-linux-android32
+        - build: linux-gcc
+          cc: gcc
+        - build: linux-clang
+          cc: clang
+        - build: linux-x86-gcc
+          cc: gcc
+          arch: x86
+        - build: linux-powerpc64-gcc
+          cc: gcc
+          host: powerpc64-linux-gnu
+        - build: linux-mingw64-gcc
+          cc: gcc
+          host: x86_64-w64-mingw32
+          cflags: -D__USE_MINGW_ANSI_STDIO
+        - build: macos
+          cc: clang
+          os: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Android NDK
+        run: |
+          if [ ${{matrix.build}} = android ]; then
+              wget --quiet https://dl.google.com/android/repository/android-ndk-r24-linux.zip; \
+              unzip -q android-ndk-r24-linux.zip; \
+          fi
+      - name: Install Ubuntu packages
+        run: |
+          sudo apt-get -q update
+          case "${{matrix.host}}" in                                        \
+            x86_64-w64-mingw32)                                             \
+              sudo apt-get -q install -y binutils-mingw-w64 gcc-mingw-w64;; \
+            powerpc64-linux-gnu)                                            \
+              sudo apt-get -q install -y binutils-powerpc64-linux-gnu       \
+              gcc-powerpc64-linux-gnu;;                                     \
+          esac
+      - name: Build
+        run: |
+          echo "HOST=${{matrix.host}}"
+          NDK=$PWD/android-ndk-r24/toolchains/llvm/prebuilt/linux-x86_64/bin
+          export PATH="$NDK:$PATH"
+          ./autogen.sh
+          ./configure --host=${{matrix.host}} \
+              CC=${{ matrix.host && format('{0}-{1}', matrix.host, matrix.cc) || matrix.cc }} \
+              CFLAGS="-Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-function -Wno-unused-parameter ${{matrix.cflags}}"
+          make -j$(nproc)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -182,7 +182,7 @@ sg_test_rwbuf_LDADD = ../lib/libsgutils2.la
 
 sg_timestamp_LDADD = ../lib/libsgutils2.la
 
-sg_turs_LDADD = ../lib/libsgutils2.la @RT_LIB@
+sg_turs_LDADD = ../lib/libsgutils2.la @RT_LIB@ @PTHREAD_LIB@
 
 sg_unmap_LDADD = ../lib/libsgutils2.la
 

--- a/src/sg_dd.c
+++ b/src/sg_dd.c
@@ -1803,7 +1803,6 @@ main(int argc, char * argv[])
     int ret = 0;
     int64_t skip = 0;
     int64_t seek = 0;
-    int64_t out2_off = 0;
     int64_t in_num_sect = -1;
     int64_t out_num_sect = -1;
     char * key;
@@ -2486,7 +2485,6 @@ main(int argc, char * argv[])
                 break;
             }
             bytes_of2 = res;
-            out2_off += res;
         }
 
         if (oflag.sparse && (dd_count > blocks) &&

--- a/src/sg_turs.c
+++ b/src/sg_turs.c
@@ -25,6 +25,7 @@
 #include <time.h>
 #include <errno.h>
 #include <getopt.h>
+#include <pthread.h> // nanosleep() for MinGW
 #define __STDC_FORMAT_MACROS 1
 #include <inttypes.h>
 


### PR DESCRIPTION
Fix the following build error:

sg_z_act_query.c:529:19: error: too many arguments to function call, expected 0,
      have 1
            usage(1);
            ~~~~~ ^

Fixes: 20315aa4fae1 ("sg_z_act_query: new utility")
Signed-off-by: Bart Van Assche <bvanassche@acm.org>