### PR TITLE
fix crash with rescan-scsi-bus.sh -r

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -307,7 +307,13 @@ testonline ()
   IPREV=$(echo "$INQ" | grep 'Product revision level:' | sed 's/^[^:]*: \(.*\)$/\1/')
   STR=$(printf "  Vendor: %-08s Model: %-16s Rev: %-4s" "$IVEND" "$IPROD" "$IPREV")
   IPTYPE=$(echo "$INQ" | sed -n 's/.* Device_type=\([0-9]*\) .*/\1/p')
+  if [ -z "$IPTYPE" ]; then
+    IPTYPE=$(echo "$INQ" | sed -n 's/.* PDT=\([0-9]*\) .*/\1/p')
+  fi
   IPQUAL=$(echo "$INQ" | sed -n 's/ *PQual=\([0-9]*\)  Device.*/\1/p')
+  if [ -z "$IPQUAL" ] ; then
+    IPQUAL=$(echo "$INQ" | sed -n 's/ *PQual=\([0-9]*\)  PDT.*/\1/p')
+  fi
   if [ "$IPQUAL" != 0 ] ; then
     [ -z "$IPQUAL" ] && IPQUAL=3
     [ -z "$IPTYPE" ] && IPTYPE=31


### PR DESCRIPTION
System was crashing when 'rescan-scsi-bus.sh -r' was run. This is because of the changes in the output of `sg_inq` command. In it, "Device_type" has been replaced with "PDT". So when Device_type is used in sed, it was passing incorrect return value to dolunscan() and hence even the internal disk from which system is booting was getting deleted. Mentioned fix takes care of both the outputs of `sg_inq` command. Only in recent `sg_inq` we see "PDT". Earlier `sg_inq` still shows "Device_type".