### PR TITLE
rescan-scsi-bus: Do not use printf for summary

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -1384,15 +1384,15 @@ fi
 
 echo "$found new or changed device(s) found.          "
 if [ ! -z "$FOUNDDEVS" ] ; then
-  printf "%s" "$FOUNDDEVS"
+  echo -e "$FOUNDDEVS"
 fi
 echo "$updated remapped or resized device(s) found."
 if [ ! -z "$CHGDEVS" ] ; then
-  printf "%s" "$CHGDEVS"
+  echo -e "$CHGDEVS"
 fi
 echo "$rmvd device(s) removed.                 "
 if [ ! -z "$RMVDDEVS" ] ; then
-  printf "%s" "$RMVDDEVS"
+  echo -e "$RMVDDEVS"
 fi
 
 # Local Variables:


### PR DESCRIPTION
A string containing escape sequences can only be supplied
to `printf` as the first argument. As there's no format involved
in the summary string, just use `echo -e` to process the escaped
sequences.

Fixes the following phenomenon:

```
1 new or changed device(s) found.
\t[1:0:0:0]\n0 remapped or resized device(s) found.
0 device(s) removed.
```

----

Very lightly tested, please double-check.