### PR TITLE
Enable continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+# See also https://docs.github.com/en/actions/learn-github-actions/expressions
+# See also https://github.com/marketplace/actions/setup-android-ndk
+
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+        - android
+        - linux-gcc
+        - linux-clang
+        - linux-x86-gcc
+        - linux-powerpc64-gcc
+        - linux-mingw64-gcc
+        - macos
+        include:
+        - build: android
+          cc: clang
+          host: aarch64-linux-android32
+        - build: linux-gcc
+          cc: gcc
+        - build: linux-clang
+          cc: clang
+        - build: linux-x86-gcc
+          cc: gcc
+          arch: x86
+        - build: linux-powerpc64-gcc
+          cc: gcc
+          host: powerpc64-linux-gnu
+        - build: linux-mingw64-gcc
+          cc: gcc
+          host: x86_64-w64-mingw32
+        - build: macos
+          cc: clang
+          os: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Android NDK
+        run: |
+          if [ ${{matrix.build}} = android ]; then \
+              wget --quiet https://dl.google.com/android/repository/android-ndk-r24-linux.zip; \
+              unzip -q android-ndk-r24-linux.zip;  \
+          fi
+      - name: Install Ubuntu packages
+        run: |
+          sudo apt-get -q update
+          case "${{matrix.host}}" in                                        \
+            x86_64-w64-mingw32)                                             \
+              sudo apt-get -q install -y binutils-mingw-w64 gcc-mingw-w64;; \
+            powerpc64-linux-gnu)                                            \
+              sudo apt-get -q install -y binutils-powerpc64-linux-gnu       \
+              gcc-powerpc64-linux-gnu;;                                     \
+          esac
+      - name: Build
+        run: |
+          echo "HOST=${{matrix.host}}"
+          NDK=$PWD/android-ndk-r24/toolchains/llvm/prebuilt/linux-x86_64/bin
+          export PATH="$NDK:$PATH"
+          ./autogen.sh
+          ./configure --host=${{matrix.host}} \
+              CC=${{ matrix.host && format('{0}-{1}', matrix.host, matrix.cc) || matrix.cc }} \
+              CFLAGS="-Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-function -Wno-unused-parameter ${{matrix.cflags}}"
+          make -j$(nproc)

--- a/include/sg_pr2serr.h
+++ b/include/sg_pr2serr.h
@@ -25,7 +25,7 @@
  * assumes that cp[0] is the null character and does nothing (and returns
  * 0). Linux kernel has a similar function called  scnprintf().  */
 
-
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdbool.h>
 

--- a/include/sg_pr2serr.h
+++ b/include/sg_pr2serr.h
@@ -65,50 +65,21 @@ typedef struct sg_json_state_t {
 } sg_json_state;
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#ifdef SG_LIB_MINGW
-/* MinGW uses Microsoft's printf */
-int pr2serr(const char * fmt, ...);
-
-int pr2ws(const char * fmt, ...);
-
-/* Want safer, 'n += snprintf(b + n, blen - n, ...)' style sequence of
- * functions. Returns number of chars placed in cp excluding the trailing null
- * char. So for cp_max_len > 0 the return value is always < cp_max_len; for
- * cp_max_len <= 1 the return value is 0 and no chars are written to cp. Note
- * this means that when cp_max_len = 1, this function assumes that cp[0] is
- * the null character and does nothing (and returns 0). Linux kernel has a
- * similar function called  scnprintf(). */
-int sg_scnpr(char * cp, int cp_max_len, const char * fmt, ...);
-
-void sgj_pr_hr(sg_json_state * jsp, const char * fmt, ...);
-
-#else   /* GNU/clang other than MinGW */
-
-int pr2serr(const char * fmt, ...)
-        __attribute__ ((format (printf, 1, 2)));
-
-int pr2ws(const char * fmt, ...)
-        __attribute__ ((format (printf, 1, 2)));
-
-int sg_scnpr(char * cp, int cp_max_len, const char * fmt, ...)
-                 __attribute__ ((format (printf, 3, 4)));
-
-void sgj_pr_hr(sg_json_state * jsp, const char * fmt, ...)
-               __attribute__ ((format (printf, 2, 3)));
+#if __USE_MINGW_ANSI_STDIO -0 == 1
+#define __printf(a, b) __attribute__((__format__(gnu_printf, a, b)))
+#elif defined(__GNUC__) || defined(__clang__)
+#define __printf(a, b) __attribute__((__format__(printf, a, b)))
+#else
+#define __printf(a, b)
 #endif
 
-#else   /* not GNU (and not clang) */
+int pr2serr(const char * fmt, ...) __printf(1, 2);
 
-int pr2serr(const char * fmt, ...);
+int pr2ws(const char * fmt, ...) __printf(1, 2);
 
-int pr2ws(const char * fmt, ...);
+int sg_scnpr(char * cp, int cp_max_len, const char * fmt, ...) __printf(3, 4);
 
-int sg_scnpr(char * cp, int cp_max_len, const char * fmt, ...);
-
-void sgj_pr_hr(sg_json_state * jsp, const char * fmt, ...);
-
-#endif
+void sgj_pr_hr(sg_json_state * jsp, const char * fmt, ...) __printf(2, 3);
 
 void sg_json_init_state(sg_json_state * jstp);
 

--- a/lib/sg_lib.c
+++ b/lib/sg_lib.c
@@ -3892,7 +3892,7 @@ sg_memalign(uint32_t num_bytes, uint32_t align_to, uint8_t ** buff_to_free,
             pr2ws("%s: hack, len=%d, ", __func__, num_bytes);
             if (buff_to_free)
                 pr2ws("buff_to_free=%p, ", wrkBuff);
-            pr2ws("align_1=%lu, rp=%p\n", align_1, (void *)res);
+            pr2ws("align_1=%" PRIuPTR "u, rp=%p\n", align_1, (void *)res);
         }
         return res;
     }


### PR DESCRIPTION
Detect portability issues more quickly by letting the Github infrastructure build sg3_utils for multiple platforms upon every push and pull request.