### PR TITLE
sg_vpd_vendor: Fix missing newline in the svpd_decode_vendor() error path

### DIFF
--- a/src/sg_vpd_vendor.c
+++ b/src/sg_vpd_vendor.c
@@ -1557,6 +1557,6 @@ svpd_decode_vendor(int sg_fd, struct opts_t * op, int off)
             return 0;
         }
     } else
-        pr2serr("Vendor VPD page=0x%x  failed to fetch", op->vpd_pn);
+        pr2serr("Vendor VPD page=0x%x  failed to fetch\n", op->vpd_pn);
     return res;
 }


### PR DESCRIPTION
This fixes the output of `sg_vpd` trying to fetch VPD pages and reporting failure:
```
...
SCSI Ports VPD page:
  Relative port=1
    Target port descriptor(s):
      designator type: NAA,  code set: Binary
       transport: Serial Attached SCSI Protocol (SPL-4)
        0x3222222000003e7e
  Relative port=2
    Target port descriptor(s):
      designator type: NAA,  code set: Binary
       transport: Serial Attached SCSI Protocol (SPL-4)
        0x3222222000003e7f

Vendor VPD page=0xc0  failed to fetchVendor VPD page=0xc1  failed to fetchVendor VPD page=0xc2  failed to fetchVendor VPD page=0xc3  failed to fetchVendor VPD page=0xc4  failed to fetchVendor VPD page=0xc5  failed to fetchVendor VPD page=0xc8  failed to fetchVendor VPD page=0xc9  failed to fetchVendor VPD page=0xca  failed to fetchVendor VPD page=0xd0  failed to fetchVendor VPD page=0xd1  failed to fetchVendor VPD page=0xd2  failed to fetch[root@localhost ~]# 
```