### PR TITLE
sg_turs: do not report error for standby or unavailable ports

### DIFF
--- a/include/sg_lib.h
+++ b/include/sg_lib.h
@@ -505,6 +505,10 @@ bool sg_exit2str(int exit_status, bool longer, int b_len, char * b);
                                     *       [sk,asc,ascq: 0xa,*,*] */
 #define SG_LIB_CAT_ABORTED_COMMAND 11 /* interpreted from sense buffer
                                        *       [sk,asc,ascq: 0xb,! 0x10,*] */
+#define SG_LIB_CAT_STANDBY 12 /* interpreted from sense buffer
+                               *      [sk,asc, ascq: 0x2, 0x4, 0xb] */
+#define SG_LIB_CAT_UNAVAILABLE 13 /* interpreted from sense buffer
+                                   *      [sk,asc, ascq: 0x2, 0x4, 0xc] */
 #define SG_LIB_CAT_MISCOMPARE 14 /* sense key, probably verify
                                   *       [sk,asc,ascq: 0xe,*,*] */
 #define SG_LIB_FILE_ERROR 15    /* device or other file problem */

--- a/lib/sg_cmds_basic.c
+++ b/lib/sg_cmds_basic.c
@@ -126,6 +126,8 @@ sg_cmds_process_helper(const char * leadin, int req_din_x, int act_din_x,
     case SG_LIB_CAT_PROTECTION:
     case SG_LIB_CAT_NO_SENSE:
     case SG_LIB_CAT_MISCOMPARE:
+    case SG_LIB_CAT_STANDBY:
+    case SG_LIB_CAT_UNAVAILABLE:
         n = false;
         break;
     case SG_LIB_CAT_RECOVERED:

--- a/lib/sg_lib.c
+++ b/lib/sg_lib.c
@@ -2244,6 +2244,10 @@ sg_err_category_sense(const uint8_t * sbp, int sb_len)
         case SPC_SK_RECOVERED_ERROR:
             return SG_LIB_CAT_RECOVERED;
         case SPC_SK_NOT_READY:
+            if ((0x04 == ssh.asc) && (0x0b == ssh.ascq))
+                return SG_LIB_CAT_STANDBY;
+            if ((0x04 == ssh.asc) && (0x0c == ssh.ascq))
+                return SG_LIB_CAT_UNAVAILABLE;
             return SG_LIB_CAT_NOT_READY;
         case SPC_SK_MEDIUM_ERROR:
         case SPC_SK_HARDWARE_ERROR:

--- a/src/sg_turs.c
+++ b/src/sg_turs.c
@@ -430,6 +430,20 @@ loop_turs(struct sg_pt_base * ptvp, struct loop_res_t * resp,
                         resp->reported = true;
                     }
                     break;
+                case SG_LIB_CAT_STANDBY:
+                    ++resp->num_errs;
+                    if (vb) {
+                        pr2serr("Ignoring standby device (sense key)\n");
+                        resp->reported = true;
+                    }
+                    break;
+                case SG_LIB_CAT_UNAVAILABLE:
+                    ++resp->num_errs;
+                    if (vb) {
+                        pr2serr("Ignoring unavailable device (sense key)\n");
+                        resp->reported = true;
+                    }
+                    break;
                 default:
                     ++resp->num_errs;
                     if (1 == op->do_number) {


### PR DESCRIPTION
This patch from @hreinecke fixes a problem where `rescan-scsi-bus.sh` was extremely slow because of repeated probing of standby devices in `testonline`. Our customer the slowness only in older releases of sg3_utils (1.43), but it should also be helpful for more recent releases.


