### PR TITLE
sg_luns: fix typo in command output: "imples" -> "implies"

### DIFF
--- a/doc/sg_luns.8
+++ b/doc/sg_luns.8
@@ -227,7 +227,7 @@ We could send a REPORT LUNS command (with \fISR\fR 0x0, 0x1 or 0x2) to any
 of those file device nodes and get the same result. Below we use /dev/sg1 :
 .PP
   # sg_luns /dev/sg1
-  Lun list length = 16 which imples 2 lun entry
+  Lun list length = 16 which implies 2 lun entries
   Report luns [select_report=0x0]:
       0001000000000000
       0002000000000000

--- a/src/sg_luns.c
+++ b/src/sg_luns.c
@@ -935,7 +935,7 @@ main(int argc, char * argv[])
         jap = sgj_named_subarray_r(jsp, jo2p, "lun_list");
         luns = (list_len / 8);
         if (! op->do_quiet)
-            sgj_pr_hr(jsp, "Lun list length = %d which imples %d lun "
+            sgj_pr_hr(jsp, "Lun list length = %d which implies %d lun "
                       "entr%s\n", list_len, luns,
                       ((1 == luns) ? "y" : "ies"));
         if ((list_len + 8) > op->maxlen) {

--- a/testing/uapi_sg.h
+++ b/testing/uapi_sg.h
@@ -167,7 +167,7 @@ typedef struct sg_scsi_id {
 typedef struct sg_req_info {	/* used by SG_GET_REQUEST_TABLE ioctl() */
 	char req_state;	/* See 'enum sg_rq_state' definition in v4 driver */
 	char orphan;	/* 0 -> normal request, 1 -> from interrupted SG_IO */
-	/* sg_io_owned set imples synchronous, clear implies asynchronous */
+	/* sg_io_owned set implies synchronous, clear implies asynchronous */
 	char sg_io_owned;/* 0 -> complete with read(), 1 -> owned by SG_IO */
 	char problem;	/* 0 -> no problem detected, 1 -> error to report */
 	/* If SG_CTL_FLAGM_TAG_FOR_PACK_ID set on fd then next field is tag */


### PR DESCRIPTION
Also fix the same typo in the manpage and in a comment in header file testing/uapi_sg.h.