### PR TITLE
Unbreak the Android build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         build:
-        - android
+        - android-23
+        - android-33
         - linux-gcc
         - linux-clang
         - linux-x86-gcc
@@ -20,7 +21,10 @@ jobs:
         - linux-mingw64-gcc
         - macos
         include:
-        - build: android
+        - build: android-23
+          cc: clang
+          host: aarch64-linux-android23
+        - build: android-33
           cc: clang
           host: aarch64-linux-android33
         - build: linux-gcc
@@ -43,10 +47,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Android NDK
         run: |
-          if [ ${{matrix.build}} = android ]; then \
+          case ${{matrix.build}} \
+          in android*) \
               wget --quiet https://dl.google.com/android/repository/android-ndk-r25c-linux.zip; \
-              unzip -q android-ndk-r25c-linux.zip;  \
-          fi
+              unzip -q android-ndk-r25c-linux.zip;;  \
+          esac
       - name: Install Ubuntu packages
         run: |
           sudo apt-get -q update

--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,20 @@ AC_CANONICAL_HOST
 AC_DEFINE_UNQUOTED(SG_LIB_BUILD_HOST, "${host}", [sg3_utils Build Host])
 
 check_for_getrandom() {
-	AC_CHECK_HEADERS([sys/random.h], [AC_DEFINE_UNQUOTED(HAVE_GETRANDOM, 1, [Found sys/random.h])], [], [])
+	AC_CHECK_HEADERS([sys/random.h])
+	AC_MSG_CHECKING([for getrandom()])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#ifdef HAVE_SYS_RANDOM_H
+#include <sys/random.h>
+#endif
+]], [[
+char buf[16];
+return getrandom(buf, sizeof(buf), 0);
+]])], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE_UNQUOTED(HAVE_GETRANDOM, 1, [Define to 1 if you have the `getrandom' function])], [
+		AC_MSG_RESULT(no)
+		])
 }
 
 check_for_linux_nvme_headers() {


### PR DESCRIPTION
The header file include/sg_pt_linux.h defines the __u64 type and is included even if the <linux/types.h> header is present and defines the __u64 type. Fix this by only defining the __u64 type if it is not defined in <linux/types.h> header.