### PR TITLE
udev rules: allow command line overrides for ID_SERIAL and symlink creation

### DIFF
--- a/scripts/00-scsi-sg3_config.rules
+++ b/scripts/00-scsi-sg3_config.rules
@@ -13,11 +13,23 @@ LABEL="scsi_identify"
 ENV{ID_SCSI_INQUIRY}=""
 
 # Set enabled unreliable sources for setting the ID_SERIAL property.
+# Set this variable to any combination of the capital letters "LTVS".
 # See 55-scsi-sg3_id.rules for detailed documentation.
 ENV{.SCSI_ID_SERIAL_SRC}="T"
+IMPORT{cmdline}="udev.scsi_id_serial_src"
+# Allow the user to override ID_SERIAL settings using "udev.scsi_id_serial_src=..."
+ENV{udev.scsi_id_serial_src}=="?*", \
+    ENV{.SCSI_ID_SERIAL_SRC}="$env{udev.scsi_id_serial_src}", \
+    ENV{udev.scsi_id_serial_src}=""
 
 # Set enabled unreliable sources for creating additional /dev/disk/by-id/scsi* symlinks.
+# Set this variable to any combination of the capital letters "LTVS".
 # See 58-scsi-sg3_symlink.rules for detailed documentation.
 ENV{.SCSI_SYMLINK_SRC}=""
+# Allow the user to override symlinks settings using "udev.scsi_symlink_src=..."
+IMPORT{cmdline}="udev.scsi_symlink_src"
+ENV{udev.scsi_symlink_src}=="?*", \
+    ENV{.SCSI_SYMLINK_SRC}="$env{udev.scsi_symlink_src}", \
+    ENV{udev.scsi_symlink_src}=""
 
 LABEL="scsi_identify_end"


### PR DESCRIPTION
commit d7b8da0 ("udev rules: restrict use of ambiguous device IDs patchset") changes device identification and symlink creation for SCSI devices.

In the worst case, these changes can cause devices to fail to be detected, and may even cause boot failure. While this is unlikely, it may be helpful to add kernel command line parameters to override the settings as a means for emergency recovery.

The parameters are "udev.scsi_id_serial_src=..." and "udev.scsi_symlink_src=... ", where the value is any combination of the letters "LTVS" for NAA *L*ocal, *T*10 vendor ID, *V*endor-specific, and *S*erial-number based identification, respectively.