### PR TITLE
rescan-scsi-bus.sh: fix multipath resize without update

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -1088,6 +1088,7 @@ findresized()
   local mpathsize=
   declare -a mpathsizes
 
+  [ -e "$TMPLUNINFOFILE" ] || getallmultipathinfo
   if [ -z "$lunsearch" ] ; then
     devs=$(ls /sys/class/scsi_device/)
   else


### PR DESCRIPTION
getallmultipathinfo() is only called from findremapped(), but we
need the information also if only findresized() is called (i.e. if
r-s-b is called with -s but without -u).

Fixes: 463fd7e ("rescan-scsi-bus: speed large multipath scans")
