### PR TITLE
sg_logs: Fix parameter lengths in show_data_compression_page

### DIFF
--- a/src/sg_logs_vendor.c
+++ b/src/sg_logs_vendor.c
@@ -492,7 +492,7 @@ show_data_compression_page(const uint8_t * resp, int len,
                 js_pcb(jsp, jo3p, bp[2]);
         }
         /* variable length integer, max length 8 bytes */
-        ull = sg_get_unaligned_be(pl - 4, bp + 4);
+        ull = sg_get_unaligned_be(pl, bp + 4);
         ccp = NULL;
         is_x100 = false;
         is_pr = false;
@@ -536,7 +536,7 @@ show_data_compression_page(const uint8_t * resp, int len,
         default:
             sgj_pr_hr(jsp, "  unknown %s = 0x%x, contents in hex:\n", param_c,
                       pc);
-            hex2str(bp + 4, pl - 4, "    ", op->h2s_oformat, blen, b);
+            hex2str(bp + 4, pl, "    ", op->h2s_oformat, blen, b);
             sgj_pr_hr(jsp, "%s\n", b);
             is_pr = true;
             break;


### PR DESCRIPTION
For the parameters in `show_data_compression_page` the length `pl` is initialized from `bp[3]` and checked for `0 || > 8`, but the value passed to `sg_get_unaligned_be` is off-by-four. So all values in this page were effectively truncated to 0.

Output from `sg_logs /dev/sg0 -p 0x1b` before
```
Data compression log page  (ssc-4) [0x1b]
  Read compression ratio x100: 0
  Write compression ratio x100: 0
  Megabytes transferred to server: 0
  Bytes transferred to server: 0
  Megabytes read from tape: 0
  Bytes read from tape: 0
  Megabytes transferred from server: 0
  Bytes transferred from server: 0
  Megabytes written to tape: 0
  Bytes written to tape: 0
  Data compression enabled: 0
  unknown Parameter code = 0xabcd, contents in hex:
    00 00 00 00
```

and after fix
```
Data compression log page  (ssc-4) [0x1b]
  Read compression ratio x100: 42
  Write compression ratio x100: 84
  Megabytes transferred to server: 1234
  Bytes transferred to server: 4567
  Megabytes read from tape: 0
  Bytes read from tape: 0
  Megabytes transferred from server: 0
  Bytes transferred from server: 0
  Megabytes written to tape: 0
  Bytes written to tape: 0
  Data compression enabled: 1
  unknown Parameter code = 0xabcd, contents in hex:
    00 00 00 00 ff 00 ff 00
```

I'm still playing around with emulation code and not an actual device, yes, so those are dummy values.
The unknown parameter was injected for the 8 byte length, the values in the page covered 1/2/4 already. I _think_ the data I'm generating is correct, but :)

(Similar-ish code in that file sometimes prefers `pl + 4` but made for a more invasive change).