### PR TITLE
sg_ses: fixed AES EI validation when EIIOE=1

### DIFF
--- a/src/sg_ses.c
+++ b/src/sg_ses.c
@@ -6549,11 +6549,11 @@ join_aes_helper(const uint8_t * ae_bp, const uint8_t * ae_last_bp,
                 if (eip && (1 == eiioe)) {         /* EIP and EIIOE=1 */
                     ei = ae_bp[3];
                     jr2p = tesp->j_base + ei;
-                    if ((ei >= tesp->num_j_eoe) ||
+                    if ((ei >= tesp->num_j_rows) ||
                         (NULL == jr2p->enc_statp)) {
-                        pr2serr("%s: oi=%d, ei=%d [num_eoe=%d], eiioe=1 "
+                        pr2serr("%s: oi=%d, ei=%d [num_rows=%d], eiioe=1 "
                                 "not in join_arr\n", __func__, k, ei,
-                                tesp->num_j_eoe);
+                                tesp->num_j_rows);
                         return broken_ei;
                     }
                     devslotnum_and_sasaddr(jr2p, ae_bp);


### PR DESCRIPTION
The sg_ses join_aes_helper() function incorrectly fails with a "not in join" error when EIIOE=1, if an element with AES is near the end of the element list.

Per SES-3, when EIIOE=1, the ELEMENT INDEX field is based on the position in the status descriptor list including overall elements.

The validation code in join_aes_helper() for this case compares ELEMENT INDEX (ei) with "num_j_eoe", which excludes overall elements. This means that if there are 5 overall elements, the join fails if any of the last 5 elements have AES.

This change compares ELEMENT INDEX (ei) with num_j_rows, which includes overall elements as expected when EIIOE=1.