### PR TITLE
rescan-scsi-bus.sh Replace 'which' with build in 'command -v'

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -1350,9 +1350,9 @@ if [ -w /sys/module/scsi_mod/parameters/default_dev_flags ] && [ $scan_flags != 
     unset OLD_SCANFLAGS
   fi
 fi
-DMSETUP=$(which dmsetup)
+DMSETUP=$(version -s dmsetup)
 [ -z "$DMSETUP" ] && flush= && mp_enable=
-MULTIPATH=$(which multipath)
+MULTIPATH=$(version -s multipath)
 [ -z "$MULTIPATH" ] && flush= && mp_enable=
 
 echo -n "Scanning SCSI subsystem for new devices"


### PR DESCRIPTION
Replace use of 'which' command to determine the existence of an
executable and replace with the built in 'command -v' to achieve
the same result. And to also remove the package dependency for
minimal environments where 'which' might not be available.