### PR TITLE
Increase max transfer length from 128M to 256M

### DIFF
--- a/src/sg_ses_microcode.c
+++ b/src/sg_ses_microcode.c
@@ -48,7 +48,7 @@
 static const char * version_str = "1.21 20230623";    /* ses4r02 */
 
 #define ME "sg_ses_microcode: "
-#define MAX_XFER_LEN (128 * 1024 * 1024)
+#define MAX_XFER_LEN (256 * 1024 * 1024)
 #define DEF_XFER_LEN (8 * 1024 * 1024)
 #define DEF_DIN_LEN (8 * 1024)
 #define EBUFF_SZ 256


### PR DESCRIPTION
This change allows microcode download of files larger than 128 MB.   