### PR TITLE
debian: modernize sg3_utils to make use of dh sequencer

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,10 +4,11 @@ Priority: optional
 Maintainer: Eric Schwartz (Skif) <emschwar@debian.org>
 Build-Depends: debhelper (>= 10), libtool, autoconf, libcam-dev [kfreebsd-i386 kfreebsd-amd64]
 Standards-Version: 4.7.0
+Rules-Requires-Root: no
 
 Package: sg3-utils
 Architecture: any
-Depends: ${shlibs:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Conflicts: sg-utils, cdwrite
 Replaces: sg-utils
 Description: utilities for devices using the SCSI command set.
@@ -19,12 +20,13 @@ Description: utilities for devices using the SCSI command set.
  commands are defined in the draft standards at www.t13.org . For a mapping
  between supported SCSI and ATA commands and utility names in this package
  see the COVERAGE file. Also some support for NVMe devices, especially via
- sg_ses to NVMe enclsoures.
+ sg_ses to NVMe enclosures.
 
 Package: libsgutils2-2
 Section: libs
-Depends: ${shlibs:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Architecture: any
+Multi-Arch: same
 Conflicts: libsgutils2
 Replaces: libsgutils2
 Suggests: sg3-utils
@@ -34,7 +36,8 @@ Description: utilities for devices using the SCSI command set (shared libraries)
 Package: libsgutils2-dev
 Section: libdevel
 Architecture: any
-Depends: libsgutils2-2 (= ${binary:Version}), ${shlibs:Depends}, ${kfreebsd:Depends}
+Multi-Arch: same
+Depends: libsgutils2-2 (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, ${kfreebsd:Depends}
 Conflicts: libsgutils1-dev
 Suggests: sg3-utils
 Description: utilities for devices using the SCSI command set (developer files)

--- a/debian/libsgutils2-2.install
+++ b/debian/libsgutils2-2.install
@@ -1,1 +1,1 @@
-usr/lib/*.so.*
+usr/lib/*/*.so.*

--- a/debian/libsgutils2-dev.install
+++ b/debian/libsgutils2-dev.install
@@ -1,4 +1,4 @@
 usr/include/scsi
-usr/lib/*.so
-usr/lib/*.la
-usr/lib/*.a
+usr/lib/*/*.so
+usr/lib/*/*.la
+usr/lib/*/*.a

--- a/debian/rules
+++ b/debian/rules
@@ -1,84 +1,21 @@
 #!/usr/bin/make -f
-# Sample debian/rules that uses debhelper. 
-# GNU copyright 1997 by Joey Hess.
-#
-# This version is for a hypothetical package that builds an
-# architecture-dependant package, as well as an architecture-independent
-# package.
 
-# Uncomment this to turn on verbose mode. 
+# Uncomment this to turn on verbose mode.
 # export DH_VERBOSE=1
 
-DEB_HOST_ARCH_OS := $(shell dpkg-architecture -qDEB_HOST_ARCH_OS 2>/dev/null)
+DEB_HOST_ARCH_OS := $(shell dpkg-architecture -q DEB_HOST_ARCH_OS 2>/dev/null)
 
-configure: configure-stamp
-configure-stamp:
-	dh_testdir
-	# Add here commands to configure the package.
-	./autogen.sh
-	CFLAGS="$(CFLAGS)" ./configure --host=$(DEB_HOST_GNU_TYPE) --build=$(DEB_BUILD_GNU_TYPE) --bindir=/usr/bin --prefix=/usr --mandir=\$${prefix}/share/man
-	touch configure-stamp
+%:
+	dh $@
 
-build: configure-stamp build-stamp
-build-stamp:
-	dh_testdir
+override_dh_compress:
+	dh_compress -X archive -X .c -X .h
 
-	# Add here commands to compile the package.
-	PREFIX=/usr MANDIR=/usr/share/man $(MAKE) -e
+override_dh_makeshlibs:
+	dh_makeshlibs -V
 
-	touch build-stamp
-
-clean:
-	dh_testdir
-	dh_testroot
-
-	# Add here commands to clean up after the build process.
-	-$(MAKE) distclean
-
-	rm -f build-stamp configure-stamp debian/substvars
-
-	dh_clean
-
-install: DH_OPTIONS=
-install: build
-	dh_testdir
-	dh_testroot
-	dh_clean
-	dh_installdirs
-
-	# Add here commands to install the package into debian/tmp
-	$(MAKE) -e install DESTDIR=$(CURDIR)/debian/tmp PREFIX=/usr
-
-	dh_install --autodest --sourcedir=debian/tmp
-
-	dh_installman
-
-# Build architecture-independent files here.
-# Pass -i to all debhelper commands in this target to reduce clutter.
-binary-indep: build install
-# nothing to do here
-
-# Build architecture-dependent files here.
-binary-arch: build install
-	dh_testdir -a
-	dh_testroot -a
-	dh_installdocs -a
-	dh_installexamples -a 
-	dh_installmenu -a
-	dh_installchangelogs ChangeLog -a
-	dh_strip -a
-	dh_link -a
-	dh_compress -a -X archive -X .c -X .h
-	dh_fixperms -a
-	dh_makeshlibs -V -v
-	dh_installdeb -a
-ifeq ($(DEB_HOST_ARCH_OS),kfreebsd)
+ifeq ($(DEB_HOST_ARCH_OS), kfreebsd)
+override_dh_gencontrol:
 	echo kfreebsd:Depends=libcam-dev >>debian/libsgutils2-dev.substvars
+	dh_gencontrol
 endif
-	dh_shlibdeps -ldebian/tmp/usr/lib -L libsgutils2
-	dh_gencontrol -a
-	dh_md5sums -a
-	dh_builddeb -a
-
-binary: binary-indep binary-arch
-.PHONY: build clean binary-indep binary-arch binary install configure


### PR DESCRIPTION
Replace old-style explicit debhelper rules with the dh sequencer, reducing debian/rules complexity.

The autogen.sh call is replaced by dh_autoreconf which runs automatically at compat 10+.

Update debian/control for Standards-Version 4.7.0 compliance:
    - Add Rules-Requires-Root: no
    - Add ${misc:Depends} to all packages
    - Add Multi-Arch: same to library packages
    - Fix typo in sg3-utils description