### PR TITLE
sg3_utils: bound device-reported lengths and guard against malformed responses

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -875,7 +875,7 @@ findremapped()
     # If udev events updated the disks already, but the multipath device isn't update
     # check for old devices to make sure we found remapped luns
     if [ -n "$mp_enable" ] && [ $remapped -eq 0 ]; then
-      findmultipath "$sddev" $id_serial
+      findmultipath "$sddev" "$id_serial"
       if [ $? -eq 1 ] ; then
         remapped=1
       fi

--- a/src/sg_copy_results.c
+++ b/src/sg_copy_results.c
@@ -126,8 +126,14 @@ scsi_failed_segment_details(uint8_t *rcBuff, unsigned int rcBuffLen)
         return;
     }
     printf("Receive copy results (failed segment details):\n");
+    if (rcBuffLen < 60) {
+        pr2serr("  <<not enough buffer for sense data>>\n");
+        return;
+    }
     printf("    Extended copy command status: %d\n", rcBuff[56]);
     senseLen = sg_get_unaligned_be16(rcBuff + 58);
+    if (senseLen > (int)(rcBuffLen - 60))
+        senseLen = (int)(rcBuffLen - 60);
     sg_get_sense_str("    ", &rcBuff[60], senseLen, 0, 1024, senseBuff);
     printf("%s", senseBuff);
 }

--- a/src/sg_vpd_vendor.c
+++ b/src/sg_vpd_vendor.c
@@ -330,42 +330,61 @@ decode_rdac_vpd_c0(uint8_t * buff, int len)
     int memsize;
     char name[65];
 
-    if (len < 3) {
+    if (len < 8) {
         pr2serr("Hardware Version VPD page length too short=%d\n", len);
         return;
     }
-    if (buff[4] != 'h' && buff[5] != 'w' && buff[6] != 'r') {
+    if (buff[4] != 'h' || buff[5] != 'w' || buff[6] != 'r') {
         pr2serr("Invalid page identifier %c%c%c%c, decoding not possible.\n",
                 buff[4], buff[5], buff[6], buff[7]);
         return;
     }
-    printf("  Number of channels: %x\n", buff[8]);
-    memsize = sg_get_unaligned_be16(buff + 10);
-    printf("  Processor Memory Size: %d\n", memsize);
-    memset(name, 0, 65);
-    memcpy(name, buff + 16, 64);
-    printf("  Board Name: %s\n", name);
-    memset(name, 0, 65);
-    memcpy(name, buff + 80, 16);
-    printf("  Board Part Number: %s\n", name);
-    memset(name, 0, 65);
-    memcpy(name, buff + 96, 12);
-    printf("  Schematic Number: %s\n", name);
-    memset(name, 0, 65);
-    memcpy(name, buff + 108, 4);
-    printf("  Schematic Revision Number: %s\n", name);
-    memset(name, 0, 65);
-    memcpy(name, buff + 112, 16);
-    printf("  Board Serial Number: %s\n", name);
-    memset(name, 0, 65);
-    memcpy(name, buff + 144, 8);
-    printf("  Date of Manufacture: %s\n", name);
-    memset(name, 0, 65);
-    memcpy(name, buff + 152, 2);
-    printf("  Board Revision: %s\n", name);
-    memset(name, 0, 65);
-    memcpy(name, buff + 154, 4);
-    printf("  Board Identifier: %s\n", name);
+    if (len > 8)
+        printf("  Number of channels: %x\n", buff[8]);
+    if (len > 11) {
+        memsize = sg_get_unaligned_be16(buff + 10);
+        printf("  Processor Memory Size: %d\n", memsize);
+    }
+    if (len >= 80) {
+        memset(name, 0, 65);
+        memcpy(name, buff + 16, 64);
+        printf("  Board Name: %s\n", name);
+    }
+    if (len >= 96) {
+        memset(name, 0, 65);
+        memcpy(name, buff + 80, 16);
+        printf("  Board Part Number: %s\n", name);
+    }
+    if (len >= 108) {
+        memset(name, 0, 65);
+        memcpy(name, buff + 96, 12);
+        printf("  Schematic Number: %s\n", name);
+    }
+    if (len >= 112) {
+        memset(name, 0, 65);
+        memcpy(name, buff + 108, 4);
+        printf("  Schematic Revision Number: %s\n", name);
+    }
+    if (len >= 128) {
+        memset(name, 0, 65);
+        memcpy(name, buff + 112, 16);
+        printf("  Board Serial Number: %s\n", name);
+    }
+    if (len >= 152) {
+        memset(name, 0, 65);
+        memcpy(name, buff + 144, 8);
+        printf("  Date of Manufacture: %s\n", name);
+    }
+    if (len >= 154) {
+        memset(name, 0, 65);
+        memcpy(name, buff + 152, 2);
+        printf("  Board Revision: %s\n", name);
+    }
+    if (len >= 158) {
+        memset(name, 0, 65);
+        memcpy(name, buff + 154, 4);
+        printf("  Board Identifier: %s\n", name);
+    }
 
     return;
 }
@@ -376,11 +395,11 @@ decode_rdac_vpd_c1(uint8_t * buff, int len)
     int i, n, v, r, m, p, d, y, num_part;
     char part[5];
 
-    if (len < 3) {
+    if (len < 14) {
         pr2serr("Firmware Version VPD page length too short=%d\n", len);
         return;
     }
-    if (buff[4] != 'f' && buff[5] != 'w' && buff[6] != 'r') {
+    if (buff[4] != 'f' || buff[5] != 'w' || buff[6] != 'r') {
         pr2serr("Invalid page identifier %c%c%c%c, decoding not possible.\n",
                 buff[4], buff[5], buff[6], buff[7]);
         return;
@@ -526,7 +545,7 @@ decode_rdac_vpd_c8(uint8_t * buff, int len)
     int label_len;
     char uuid[33];
     int uuid_len;
-    uint8_t port_id[128];
+    uint8_t port_id[224]; /* RFC 3720 iSCSI names can be up to 223 bytes */
     int n;
 
     if (len < 0xab) {
@@ -541,11 +560,14 @@ decode_rdac_vpd_c8(uint8_t * buff, int len)
     }
 
     uuid_len = buff[11];
+    if (uuid_len > 16)
+        uuid_len = 16;
 
     for (i = 0, c = uuid; i < uuid_len; i++) {
         sprintf(c,"%02x",buff[12 + i]);
         c += 2;
     }
+    *c = '\0';
 
     printf("  Volume Unique Identifier: %s\n", uuid);
 #ifndef SG_LIB_MINGW
@@ -559,20 +581,27 @@ decode_rdac_vpd_c8(uint8_t * buff, int len)
 #endif
     memset(label, 0, 61);
     label_len = buff[28];
+    if (label_len > (int)sizeof(label))
+        label_len = (int)sizeof(label);
     for(i = 0; i < (label_len - 1); ++i)
         *(label + i) = buff[29 + (2 * i) + 1];
     printf("  Volume User Label: %s\n", label);
 
     uuid_len = buff[89];
+    if (uuid_len > 16)
+        uuid_len = 16;
 
     for (i = 0, c = uuid; i < uuid_len; i++) {
         sprintf(c,"%02x",buff[90 + i]);
         c += 2;
     }
+    *c = '\0';
 
     printf("  Storage Array Unique Identifier: %s\n", uuid);
     memset(label, 0, 61);
     label_len = buff[106];
+    if (label_len > (int)sizeof(label))
+        label_len = (int)sizeof(label);
     for(i = 0; i < (label_len - 1); ++i)
         *(label + i) = buff[107 + (2 * i) + 1];
     printf("  Storage Array User Label: %s\n", label);
@@ -586,7 +615,7 @@ decode_rdac_vpd_c8(uint8_t * buff, int len)
 
     /* Initiator transport ID */
     if ( buff[10] & 0x01 ) {
-        memset(port_id, 0, 128);
+        memset(port_id, 0, sizeof(port_id));
         printf("  Transport Protocol: ");
         switch (buff[175] & 0x0F) {
         case TPROTO_FCP: /* FC */
@@ -602,7 +631,12 @@ decode_rdac_vpd_c8(uint8_t * buff, int len)
         case TPROTO_ISCSI: /* iSCSI */
             printf("iSCSI\n");
             n = sg_get_unaligned_be32(buff + 177);
+            if (n > (int)sizeof(port_id) - 1)
+                n = (int)sizeof(port_id) - 1;
+            if (n > len - 179)
+                n = len - 179;
             memcpy(port_id, &buff[179], n);
+            port_id[n] = '\0';
             n = 179 + n;
             break;
         case TPROTO_SAS: /* SAS */
@@ -616,7 +650,7 @@ decode_rdac_vpd_c8(uint8_t * buff, int len)
 
         printf("  Initiator Port Identifier: %s\n", port_id);
         if ( buff[10] & 0x02 ) {
-            memset(port_id, 0, 128);
+            memset(port_id, 0, sizeof(port_id));
             memcpy(port_id, &buff[n], 8);
             printf("  Supplemental Vendor ID: %s\n", port_id);
         }

--- a/src/sg_xcopy.c
+++ b/src/sg_xcopy.c
@@ -797,15 +797,15 @@ scsi_operating_parameter(struct xcopy_fp_t *xfp, int is_target)
                     1 << rcBuff[38]);
         if (rcBuff[39] > 30)
             pr2serr("    Held data granularity: 2**%u bytes\n",
-                    1 << rcBuff[39]);
+                    rcBuff[39]);
         else
             pr2serr("    Held data granularity: %u bytes\n", 1 << rcBuff[39]);
 
         pr2serr("    Implemented descriptor list:\n");
     }
-    xfp->min_bytes = 1 << rcBuff[37];
+    xfp->min_bytes = (rcBuff[37] < 32) ? 1U << rcBuff[37] : 0;
 
-    for (n = 0; n < rcBuff[43]; n++) {
+    for (n = 0; n < rcBuff[43] && (44 + n) < rcBuffLen; n++) {
         switch(rcBuff[44 + n]) {
         case 0x00: /* copy block to stream device */
             if (!is_target && (ftype & FT_BLOCK))

--- a/src/sginfo.c
+++ b/src/sginfo.c
@@ -913,6 +913,8 @@ get_mode_page10(struct mpage_info * mpi, int llbaa, int dbd,
         }
     }
     mpi->resp_len = (resp[0] << 8) + resp[1] + 2;
+    if (mpi->resp_len > MAX_RESP10_SIZE)
+        mpi->resp_len = MAX_RESP10_SIZE;
     if (sngl_fetch) {
         if (trace_cmd > 1) {
             off = modePageOffset(resp, mpi->resp_len, 0);
@@ -1043,6 +1045,8 @@ put_mode_page10(struct mpage_info * mpi, const uint8_t * msense10_resp,
 
     bdlen = (msense10_resp[6] << 8) + msense10_resp[7];
     resplen = (msense10_resp[0] << 8) + msense10_resp[1] + 2;
+    if (resplen > SIZEOF_BUFFER1)
+        resplen = SIZEOF_BUFFER1;
 
     cmd[0] = SMODE_SELECT_10;
     cmd[1] = 0x10 | (sp_bit ? 1 : 0); /* always set PF bit */


### PR DESCRIPTION
This series addresses buffer overflows and undefined behaviour triggered
by malicious or misbehaving SCSI devices returning out-of-spec values in
VPD pages, mode pages, and extended copy responses. All fixes are
defensive bounds checks only, there are no output or behavioural changes 
for compliant devices.                  
                         
sg_vpd_vendor.c (decode_rdac_vpd_c8):            
    - Bound iSCSI port identifier to 223 bytes (RFC 3720 maximum)
    - Clamp uuid_len to 16 and label_len to buffer size
    - Null-terminate uuid and port_id after writes
  
  sg_vpd_vendor.c (decode_rdac_vpd_c0):            
    - Raise minimum length check from 3 to 8
    - Fix logic bug in page identifier check (&& to ||)
    - Add progressive length checks before each field access

  sg_vpd_vendor.c (decode_rdac_vpd_c1):
    - Raise minimum length check from 3 to 14
    - Fix same && to || logic bug in identifier check

  sginfo.c (get_mode_page10, put_mode_page10):
    - Bound device-reported mode data length to buffer size

  sg_xcopy.c (scsi_operating_parameter):
    - Guard left-shift of device-reported exponent against UB (>= 32)
    - Bound device-reported descriptor loop to buffer size
    - Fix verbose print passing computed value instead of exponent

  sg_copy_results.c (scsi_failed_segment_details):
    - Bound device-reported sense data length to buffer size

  rescan-scsi-bus.sh (findremapped):
    - Quote $id_serial to prevent word splitting on serial numbers
      containing spaces (permitted by SPC-4/5 VPD page 0x80)