### PR TITLE
rescan-scsi-bus.sh: fix broken command existence checks for dmsetup a…

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -1362,9 +1362,9 @@ if [ -w /sys/module/scsi_mod/parameters/default_dev_flags ] && [ $scan_flags != 
     unset OLD_SCANFLAGS
   fi
 fi
-DMSETUP=$(version -s dmsetup)
+DMSETUP=$(command -v dmsetup)
 [ -z "$DMSETUP" ] && flush= && mp_enable=
-MULTIPATH=$(version -s multipath)
+MULTIPATH=$(command -v multipath)
 [ -z "$MULTIPATH" ] && flush= && mp_enable=
 
 echo -n "Scanning SCSI subsystem for new devices"


### PR DESCRIPTION
…nd multipath

Replace invalid "version -s" calls with "command -v". Commit 2368758 reported to make this change when from which.

"version" command does not exist as a bash built-in.