### PR TITLE
Fix some metadata in the cpack-built FreeBSD package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,10 +293,11 @@ set(CPACK_RPM_COMPONENT_INSTALL YES)
 # FreeBSD
 #
 
-set(CPACK_FREEBSD_PACKAGE_LICENSE "BSD-2-clause")
+set(CPACK_FREEBSD_PACKAGE_LICENSE "BSD2CLAUSE")
 set(CPACK_FREEBSD_PACKAGE_ORIGIN "github.com/doug-gilbert/sg3_utils")
 set(CPACK_FREEBSD_PACKAGE_MAINTAINER "dgilbert@interlog.com")
 set(CPACK_FREEBSD_PACKAGE_WWW "https://doug-gilbert.github.io/sg3_utils.html")
+set(CPACK_FREEBSD_PACKAGE_CATEGORIES "sysutils")
 
 if ( SG_LIB_LINUX )
     SET(CPACK_GENERATOR "DEB;RPM")


### PR DESCRIPTION
* Use the conventional spelling for the license
* Set the categories correctly