### PR TITLE
sg_inq: --export output conformance for SCSI name string and ATA fields

### DIFF
--- a/inhex/tst_script.sh
+++ b/inhex/tst_script.sh
@@ -89,5 +89,19 @@ sg_vpd -I vpd_zbdc.hex
 
 sg_z_act_query --inhex=z_act_query.hex
 
+echo ""
+echo ">>>>>>>>>>>>>>>> sg_inq --export udev encoding conformance test"
+# VPD 0x83 designator type 8 (SCSI name string) udev encoding conformance
+# test. The --export output must be in conformance with other udev character
+# encoding rules.
+export_output=$(sg_inq --export --inhex=vpd_di_name_inject.hex 2>/dev/null)
+export_lines=$(echo "$export_output" | wc -l)
+if [ "$export_lines" -eq 1 ] && echo "$export_output" | grep -q '\\x0a'; then
+    echo "PASS: SCSI name string is udev conformed character encoding ($export_lines line)"
+else
+    echo "FAIL: expected udev conformance, instead got $export_lines line(s):"
+    echo "$export_output"
+fi
+
 # D. Gilbert, last updated 20230420
 

--- a/inhex/vpd_di_name_inject.hex
+++ b/inhex/vpd_di_name_inject.hex
@@ -1,0 +1,18 @@
+#
+# VPD page 0x83 with a SCSI name string (designator type 8) testing
+# udev udev-conforming character encoding.
+#
+# Used to test that sg_inq --export conforms as expected.
+#
+# Identifier: iqn.2026-05.sg3\nX_SG3_PROBE=1
+#
+# An example invocation:
+#    sg_inq --export --inhex=vpd_di_name_inject.hex --raw
+
+00 83 00 24
+
+# SCSI name string designator (type 8, code set 3 UTF-8, association 0 LUN)
+# descriptor header: code_set=3, assoc=0, desig_type=8, length=0x1d
+03 08 00 1d
+69 71 6e 2e 32 30 32 36  2d 30 35 2e 73 67 33 0a
+58 5f 53 47 33 5f 50 52  4f 42 45 3d 31 00 00 00

--- a/src/sg_inq.c
+++ b/src/sg_inq.c
@@ -1923,8 +1923,17 @@ export_dev_ids(uint8_t * buff, int len, int verbose)
                 }
                 printf("\n");
                 if (!memcmp(ip, "ATA_", 4)) {
-                    printf("SCSI_IDENT_%s_ATA=%.*s\n", assoc_str,
-                           k - 4, ip + 4);
+                    printf("SCSI_IDENT_%s_ATA=", assoc_str);
+                    for (m = 4; m < k; ++m) {
+                        if ((ip[m] >= '0' && ip[m] <= '9') ||
+                            (ip[m] >= 'A' && ip[m] <= 'Z') ||
+                            (ip[m] >= 'a' && ip[m] <= 'z') ||
+                            strchr("#+-.:=@_", ip[m]) != NULL)
+                            printf("%c", ip[m]);
+                        else
+                            printf("\\x%02x", ip[m]);
+                    }
+                    printf("\n");
                 }
             } else {
                 for (m = 0; m < i_len; ++m)
@@ -2047,8 +2056,17 @@ export_dev_ids(uint8_t * buff, int len, int verbose)
                 break;
             }
 
-            printf("SCSI_IDENT_%s_NAME=%.*s\n", assoc_str, i_len,
-                   (const char *)ip);
+            printf("SCSI_IDENT_%s_NAME=", assoc_str);
+            for (m = 0; m < i_len; ++m) {
+                if ((ip[m] >= '0' && ip[m] <= '9') ||
+                    (ip[m] >= 'A' && ip[m] <= 'Z') ||
+                    (ip[m] >= 'a' && ip[m] <= 'z') ||
+                    strchr("#+-.:=@_", ip[m]) != NULL)
+                    printf("%c", ip[m]);
+                else
+                    printf("\\x%02x", ip[m]);
+            }
+            printf("\n");
             break;
         case 9: /*  Protocol specific port identifier */
             if (TPROTO_UAS == p_id) {


### PR DESCRIPTION
Apply udev-conforming character encoding to VPD 0x83 designator type 8 (SCSI name string) and the T10 vendor ID ATA subfield, matching the encoding already used by designator types 0 and 1 since commit 4d770f10.

Add inhex test data for SCSI name string designator validation.